### PR TITLE
Configure Jest to load ES modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,8 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
-const esModules = ['ky', 'ky-universal'].join('|');
-
-module.exports = {
+export default {
   testEnvironment: 'jsdom',
 
-  transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
+  transform: {}
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -26,7 +27,7 @@
   },
   "scripts": {
     "build": "webpack",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "test-experiment": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,15 +1,5 @@
 import ky from 'ky-universal';
 
-// will fail if babel config is not used
-class Foo {
-  #bar = "bar";
-
-  test(obj) {
-    return #bar in obj;
-  }
-}
-
-
 test('hello', () => {
   console.log('hello, world');
 })


### PR DESCRIPTION
This PR gets `npm test` passing while importing `ky-universal` within the Jest environment.

However, I haven't tried to get the Babel config working. I deleted the relevant code that requires Babel, for now. I assume this could be added back without too much trouble.